### PR TITLE
1.4.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,26 @@
 # ANT upload checker
 
 ## What does this script do?
-This script is intended to be used on a directory containing films. It scans for films, parses their film titles and checks whether each film already exists on ANT. The script outputs a csv file containing the film list along with info on whether it's been uploaded or not. The idea is to help find films in your library that could potentially be uploaded.
+This script is intended to be used on a directory containing films. It scans for films, parses their film titles and resolutions, and checks whether a given film and its resolution already exists on ANT. The script outputs a csv file containing the film list along with information on whether it's been uploaded or not. The idea is to help find films in your library that could potentially be uploaded.
 
 Example CSV output:
 
-| Full file path                                             | Film size (GB) | Parsed film title | Already on ANT? |
-|------------------------------------------------------------|----------------|-------------------|-----------------|
-| C:\Movies\Asteroid City (2023)\Asteroid.City.2023.1080.mkv | 10.62          | Asteroid City     | url       |
-| C:\Movies\A made up film (2023)\A made up film (2023).mp4  | 5.14           | A made up film    | NOT FOUND       |
+| Full file path                                                  | Parsed film title | Film size (GB) | Resolution | Already on ANT?                                                     |
+|-----------------------------------------------------------------|-------------------|----------------|------------|---------------------------------------------------------------------|
+| C:\Movies\Asteroid City (2023)\Asteroid.City.2023.1080p.mkv     | Asteroid City     | 10.62          | 1080p      | Resolution already uploaded: (link to film)                         |
+| C:\Movies\Cold War (2018)\Cold.War.2018.mkv                     | Cold War          | 5.01           |            | On ANT, but could not get resolution from file name: (link to film) |
+| C:\Movies\A made up film (2023)\A made up film (2023) 2160p.mp4 | A made up film    | 5.14           | 2160p      | NOT FOUND                                                           |
+
+
 
 
 ## :grey_question: How does it work?
 
-The process searches through the given directory (or multiple directories), and finds all common video file formats (currently: mp4, avi, mkv, mpeg and m2ts). Using an existing package called [guessit](https://github.com/guessit-io/guessit) and some additional work, film titles are parsed from the file paths.
+The process searches through the given directory (or multiple directories), and finds all common video file formats (currently: mp4, avi, mkv, mpeg and m2ts). Using an existing package called [guessit](https://github.com/guessit-io/guessit) and some additional processing, film titles and their resolutions are parsed from the file paths.
 
-The script outputs a csv file containing a list of films it's found, with the link to the ANT torrent if it already exists, or "NOT FOUND" if not.
+The script outputs a csv file containing a list of films it's found and whether they've been found on ANT or not.
 
-As of version 1.4, if an existing film_list.csv is found in the output location specified, any films in this that have already been found on ANT will be skipped by the process. This means you can re-run the script without having to search through your whole film library again. It will not skip films that were not found on ANT, and any new films in your library.
+If an existing film_list.csv is found in the output location specified, any films in this that have already been found on ANT will be skipped by the process. This means you can re-run the script without having to search through your whole film library again. It will not skip films that were not found on ANT, and any new films in your library.
 
 This is a work in progress - please feel free to give helpful feedback and report bugs.
 
@@ -25,7 +28,6 @@ This is a work in progress - please feel free to give helpful feedback and repor
 * Non-english films may not be found on ANT if their titles do not match
 * Films with ellipsis may not be found. Currently guessit automatically removes these e.g. Tick Tick... BOOM! -> Tick Tick Boom!
 * Films with alternate titles (Film X AKA Film Y) will not be found on ANT
-* Film titles that should contain symbols like "/" or ":" but don't in their file names aren't found on ANT
 
 ## :clipboard: Prerequisites
 * You must have Python v 3.8 or later installed: https://www.python.org/downloads/windows/
@@ -50,9 +52,11 @@ This is a work in progress - please feel free to give helpful feedback and repor
 
 
 ## :rainbow: Future versions
-### Version 1.4.3
-- [ ] Add resolution dupe check https://github.com/pizzaolive/ant_upload_checker/issues/16. Process will check if the specific resolution of your films are on ANT already or not.
+### Version 1.4.4
+- [ ] Look into fix for films with alternate titles (x AKA y)
 
+### Version 1.4.3
+- [x] Add resolution dupe check https://github.com/pizzaolive/ant_upload_checker/issues/16. Process will check if the specific resolution of your films are on ANT already or not.
 
 ### Version 1.4.2
 - [x] Fix for films that should contain "/" or ":" within times or dates in tiles https://github.com/pizzaolive/ant_upload_checker/issues/5 
@@ -61,6 +65,6 @@ This is a work in progress - please feel free to give helpful feedback and repor
 ## :bulb: Future ideas 
 * Look into using tmdb or imdb to match films first, if that fails, rely on title
 * Add ability to exclude TV shows if some are found within directory
-* Use enquirer or GUI to select folder paths?
+* Use enquirer or GUI to select folder paths
 
 

--- a/ant_upload_checker/film_searcher.py
+++ b/ant_upload_checker/film_searcher.py
@@ -139,7 +139,6 @@ class FilmSearcher:
             "q": film_title,
             "t": "movie",
             "o": "json",
-            "limit": 1,
         }
 
         try:
@@ -164,8 +163,8 @@ class FilmSearcher:
         if response_json["response"]["total"] == 0:
             return "NOT FOUND"
         else:
-            torrent_link = response_json["item"][0]["guid"]
-            return torrent_link
+            return response_json["item"]
+            # return torrent id and resolution?
 
     def replace_word_and_re_search(self, film_title, regex_pattern, replacement):
         cleaned_film_title = re.sub(

--- a/ant_upload_checker/film_searcher.py
+++ b/ant_upload_checker/film_searcher.py
@@ -26,11 +26,9 @@ class FilmSearcher:
         search for these on ANT, indicating whether they exist on ANT or not.
         """
         films_to_skip = self.film_list_df.loc[
-            ~(
-                self.film_list_df["Already on ANT?"]
-                .astype(str)
-                .str.contains(r"(?i)NOT FOUND|nan", regex=True)
-            )
+            self.film_list_df["Already on ANT?"]
+            .astype(str)
+            .str.contains("torrentid", regex=True)
         ]
         if not films_to_skip.empty:
             logging.info(
@@ -75,7 +73,10 @@ class FilmSearcher:
             return api_response
 
         if film_resolution == "":
-            return "On ANT, but could not get resolution from file name"
+            return (
+                "On ANT, but could not get resolution from file name: "
+                f"{api_response[0]['guid']}"
+            )
 
         for match in api_response:
             if match["resolution"] == film_resolution:
@@ -171,14 +172,23 @@ class FilmSearcher:
             "o": "json",
         }
 
+        response = self.session.get(url, params=payload)
         try:
-            response = self.session.get(url, params=payload)
             response.raise_for_status()
             response_json = response.json()
         except requests.exceptions.HTTPError as err:
             logging.error(
-                "Connection error: this could be caused by an incorrect API key\n"
+                "HTTP Error: %s",
+                err,
             )
+            if response.status_code == 429:
+                logging.error(
+                    "Try increasing the API search period limit to greater than 2"
+                )
+            elif response.status_code == 403:
+                logging.error(
+                    "Your API key may be invalid. Check the key in parameters.py"
+                )
             raise SystemExit(err)
         except requests.exceptions.ConnectionError as err:
             logging.error("Connection error despite retries, exiting process\n")
@@ -201,7 +211,7 @@ class FilmSearcher:
             replacement,
             film_title,
         )
-        logging.info("-- Searching for %s as well...", cleaned_film_title)
+        logging.info("-- Searching for %s as well...\n", cleaned_film_title)
         film_check = self.search_for_film_title_on_ant(cleaned_film_title)
 
         return film_check

--- a/ant_upload_checker/tests/test_film_processor.py
+++ b/ant_upload_checker/tests/test_film_processor.py
@@ -56,13 +56,13 @@ def test_film_paths():
     return test_list
 
 
-def test_get_film_title_from_path(test_film_paths):
+def test_get_film_title_from_guessed_film(test_film_paths):
     # Note the issues with some acronyms with guessit
     # Note path parent folder is taken e.g. Atlantics instead of Atlantique
     # Where the year is in brackets ()
     fp = FilmProcessor("test", "test")
 
-    actual_list = [fp.get_film_title_from_path(x) for x in test_film_paths]
+    actual_list = [fp.get_film_title_from_guessed_film(x) for x in test_film_paths]
     expected_list = [
         "Atlantics",
         "tick tick BOOM!",
@@ -122,9 +122,9 @@ def test_fix_title_if_contains_acronym():
     assert actual_list == expected_list
 
 
-def test_get_formatted_titles_from_film_paths(test_film_paths):
+def test_get_formatted_titles_from_guessed_films(test_film_paths):
     fp = FilmProcessor("test", "test")
-    actual_list = fp.get_formatted_titles_from_film_paths(test_film_paths)
+    actual_list = fp.get_formatted_titles_from_guessed_films(test_film_paths)
 
     expected_list = [
         "Atlantics",

--- a/ant_upload_checker/tests/test_film_processor.py
+++ b/ant_upload_checker/tests/test_film_processor.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from ant_upload_checker.film_processor import FilmProcessor
 import pandas as pd
 import numpy as np
+from collections import OrderedDict
 
 LOGGER = logging.getLogger(__name__)
 
@@ -37,32 +38,59 @@ def test_remove_paths_containing_extras_folder(test_extras_file_paths):
 @pytest.fixture
 def test_film_paths():
     test_list = [
-        r"C:/Atlantics (2019)/Atlantique.2019.mkv",
-        r"C:/tick tick... BOOM! 2021 test.mkv",
-        r"C:/Da.5.Bloods.2020.test.mkv",
-        r"C:/Short term 12 2013/Short term 12 2013 film info.mkv",
-        r"C:/X: First Class (2100)",
-        r"C:/Nick Fury: Agent of S.H.I.E.L.D. (1998).mkv",
-        r"C:/L.A. Confidential (1997) test.mkv",
-        r"C:/A.I. Artificial Intelligence (2100)",
-        r"C:/G.I. Jane (2100)",
-        r"C:/E.T. the Extra-Terrestrial (2100)",
-        r"C:/S.W.A.T. (2100)",
-        r"C:/T.E.S. Test film (2010)",
-        r"C:/T.E.S.T. Test film (2010)",
+        r"C:/Atlantics (2019)/Atlantique.2019.2160p.mkv",
+        r"C:/tick tick... BOOM! 2021 test.720p.mkv",
+        r"C:/Da.5.Bloods.2020..1080p.test.mkv",
+        r"C:/Short term 12 2013/Short term 12 2013.1080p.film info.mkv",
+        r"C:/X: First Class (2100).1080p.mkv",
+        r"C:/Nick Fury: Agent of S.H.I.E.L.D. (1998).1080p.mkv",
+        r"C:/L.A. Confidential (1997) .1080p.mkv",
+        r"C:/A.I. Artificial Intelligence (2100).1080p.mkv",
+        r"C:/G.I. Jane (2100).mkv",
+        r"C:/E.T. the Extra-Terrestrial (2100).1080p.mkv",
+        r"C:/S.W.A.T. (2100).1080p.mkv",
+        r"C:/T.E.S. Test film (2010).1080p.mkv",
+        r"C:/T.E.S.T. Test film (2010).1080p.mkv",
     ]
     test_list = [Path(x) for x in test_list]
 
     return test_list
 
 
-def test_get_film_title_from_guessed_film(test_film_paths):
-    # Note the issues with some acronyms with guessit
-    # Note path parent folder is taken e.g. Atlantics instead of Atlantique
-    # Where the year is in brackets ()
+@pytest.fixture
+def test_guessit_films():
+    test_guessit_films = [
+        {"title": "Atlantics", "screen_size": "2160p"},
+        {"title": "tick tick BOOM!", "screen_size": "720p"},
+        {"title": "Da 5 Bloods", "screen_size": "1080p"},
+        {"title": "Short term 12", "screen_size": "1080p"},
+        {"title": "X: First Class", "screen_size": "1080p"},
+        {"title": "Nick Fury: Agent of S.H.I.E.L.D.", "screen_size": "1080p"},
+        {"title": "L A Confidential", "screen_size": "1080p"},
+        {"title": "A I Artificial Intelligence", "screen_size": "1080p"},
+        {"title": "G I Jane"},
+        {"title": "E T the Extra-Terrestrial", "screen_size": "1080p"},
+        {"title": "S.W.A.T.", "screen_size": "1080p"},
+        {"title": "T E S Test film", "screen_size": "1080p"},
+        {"title": "T E.S.T Test film", "screen_size": "1080p"},
+    ]
+    ordered_dict_guessit_films = [OrderedDict(x) for x in test_guessit_films]
+
+    return ordered_dict_guessit_films
+
+
+def test_get_guessit_info_from_film_paths(test_film_paths):
+    fp = FilmProcessor("test", "test")
+    actual_guessit_films = fp.get_guessit_info_from_film_paths(test_film_paths)
+
+    expected_type = OrderedDict
+    assert all([isinstance(x, expected_type) for x in actual_guessit_films])
+
+
+def test_get_film_title_from_guessed_film(test_guessit_films):
     fp = FilmProcessor("test", "test")
 
-    actual_list = [fp.get_film_title_from_guessed_film(x) for x in test_film_paths]
+    actual_list = [fp.get_film_title_from_guessed_film(x) for x in test_guessit_films]
     expected_list = [
         "Atlantics",
         "tick tick BOOM!",
@@ -122,9 +150,9 @@ def test_fix_title_if_contains_acronym():
     assert actual_list == expected_list
 
 
-def test_get_formatted_titles_from_guessed_films(test_film_paths):
+def test_get_formatted_titles_from_guessed_films(test_guessit_films):
     fp = FilmProcessor("test", "test")
-    actual_list = fp.get_formatted_titles_from_guessed_films(test_film_paths)
+    actual_list = fp.get_formatted_titles_from_guessed_films(test_guessit_films)
 
     expected_list = [
         "Atlantics",
@@ -145,6 +173,28 @@ def test_get_formatted_titles_from_guessed_films(test_film_paths):
     assert actual_list == expected_list
 
 
+def test_get_film_resolutions_from_guessed_film(test_guessit_films):
+    fp = FilmProcessor("test", "test")
+    actual_list = fp.get_film_resolutions_from_guessed_films(test_guessit_films)
+    expected_list = [
+        "2160p",
+        "720p",
+        "1080p",
+        "1080p",
+        "1080p",
+        "1080p",
+        "1080p",
+        "1080p",
+        "",  # File name for G.I. Jane has no resolution - expect ""
+        "1080p",
+        "1080p",
+        "1080p",
+        "1080p",
+    ]
+
+    assert actual_list == expected_list
+
+
 def test_create_film_list_dataframe():
     fp = FilmProcessor("test", "test")
     test_film_paths = [
@@ -153,9 +203,10 @@ def test_create_film_list_dataframe():
     ]
     test_film_titles = ["X: First Class", "Short term 12"]
     test_film_sizes = [5.11, 2.14]
+    test_film_resolutions = ["1080p", "1080p"]
 
     actual_df = fp.create_film_list_dataframe(
-        test_film_paths, test_film_sizes, test_film_titles
+        test_film_paths, test_film_sizes, test_film_titles, test_film_resolutions
     )
 
     expected_df = pd.DataFrame(
@@ -163,10 +214,10 @@ def test_create_film_list_dataframe():
             "Full file path": [
                 r"C:\X: First Class (2100)",
                 r"C:\Short term 12 2013\Short term 12 2013 film info.mkv",
-
             ],
-            "Film size (GB)": [5.11,2.14],
-            "Parsed film title": ["X: First Class","Short term 12"],
+            "Parsed film title": ["X: First Class", "Short term 12"],
+            "Film size (GB)": [5.11, 2.14],
+            "Resolution": ["1080p", "1080p"],
             "Already on ANT?": [np.nan, np.nan],
         }
     )
@@ -188,17 +239,42 @@ def test_false_get_existing_film_list_if_exists(tmp_path, caplog):
 
     fp = FilmProcessor(input_folders="", output_folder=tmp_path)
 
-    assert fp.get_existing_film_list_if_exists() == False
+    assert fp.get_existing_film_list_if_exists() == None
     assert "An existing output file" in caplog.text
+
+
+def test_get_existing_film_list_if_exists_previous_version(tmp_path, caplog):
+    caplog.set_level(logging.INFO)
+    test_df = pd.DataFrame(
+        {
+            "Full file path": ["test", "test"],
+            "Parsed film title": ["test", "test"],
+            "Film size (GB)": ["test", "test"],
+            "Already on ANT?": ["test", "test"],
+        }
+    )
+    test_df.to_csv(tmp_path.joinpath("Film list.csv"), index=False)
+
+    fp = FilmProcessor(input_folders="", output_folder=tmp_path)
+    actual_return_value = fp.get_existing_film_list_if_exists()
+
+    assert Path.is_file(tmp_path.joinpath("Film list old version backup.csv"))
+    assert (
+        "Warning: existing file was created using an old version of ANT upload checker"
+        in caplog.text
+    )
+    assert actual_return_value == None
 
 
 def test_true_get_existing_film_list_if_exists(tmp_path, caplog):
     caplog.set_level(logging.INFO)
     test_df = pd.DataFrame(
         {
-            "Full file path": ["test"],
-            "Film size (GB)": 10.11,
-            "Parsed film title": "test",
+            "Full file path": ["test", "test"],
+            "Parsed film title": ["test", "test"],
+            "Film size (GB)": [10.11, 5.22],
+            "Resolution": ["1080p", "1080p"],
+            "Already on ANT?": ["test", "test"],
         }
     )
     test_df.to_csv(tmp_path.joinpath("Film list.csv"), index=False)
@@ -208,9 +284,11 @@ def test_true_get_existing_film_list_if_exists(tmp_path, caplog):
 
     expected_df = pd.DataFrame(
         {
-            "Full file path": ["test"],
-            "Film size (GB)": 10.11,
-            "Parsed film title": "test",
+            "Full file path": ["test", "test"],
+            "Parsed film title": ["test", "test"],
+            "Film size (GB)": [10.11, 5.22],
+            "Resolution": ["1080p", "1080p"],
+            "Already on ANT?": ["test", "test"],
         }
     )
 

--- a/ant_upload_checker/tests/test_film_searcher.py
+++ b/ant_upload_checker/tests/test_film_searcher.py
@@ -42,6 +42,7 @@ def test_check_if_films_exist_on_ant(
             ],
             "Film size (GB)": [1.11, 1.22, 1.33, 1.44],
             "Parsed film title": ["Test", "Another film", "test film", "New film"],
+            "Resolution": ["1080p", "1080p", "1080p", "1080p"],
             "Already on ANT?": ["link/torrentid=1", "NOT FOUND", np.nan, np.nan],
         }
     )
@@ -68,6 +69,7 @@ def test_check_if_films_exist_on_ant(
                 "Test",
                 "test film",
             ],
+            "Resolution": ["1080p", "1080p", "1080p", "1080p"],
             "Already on ANT?": [
                 "NOT FOUND",
                 "NOT FOUND",

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+Version 1.4.3
+* Process now checks if a film's specific resolution is already uploaded to ANT as well. If the resolution is missing then it can likely be uploaded even if the film exists on ANT. If the resolution can't be extracted from the file name, then it will just check if it exists on ANT.
+* If a film_list.csv is found from previous versions, this won't be compatible with this new update, so if a file is found, this is backed up in case users want this to be kept.
+* Fixed error handling logging messages and added messages for specific status codes user might encounter.
+
 Version 1.4.2 
 * Attempt fix for an issue where films with titles containing numbers (potential times or dates) were not found. These are now re-searched if not found.
     * E.g. Fahrenheit 911 -> Fahrenheit 9/11. Test film 1008 -> Test film 10:08

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ANT_upload_checker"
-version = "1.4.2"
+version = "1.4.3"
 authors = [
     { name = "pizzaolive"}
 ]


### PR DESCRIPTION
Closes #16 
* Process now checks if a film's specific resolution is already uploaded to ANT as well. If the resolution is missing then it can likely be uploaded even if the film exists on ANT. If the resolution can't be extracted from the file name, then it will just check if it exists on ANT.
* If a film_list.csv is found from previous versions, this won't be compatible with this new update, so if a file is found, this is backed up in case users want this to be kept.
* Fixed error handling logging messages and added messages for specific status codes user might encounter.