### PR TITLE
1.4.4 - Fix issue #4 alternate titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,13 @@ This is a work in progress - please feel free to give helpful feedback and repor
 
 
 ## :rainbow: Future versions
-### Version 1.4.4
-- [ ] Look into fix for films with alternate titles (x AKA y)
+### Version 1.4.5
+- [ ] Add check for parameters file, start to introduce enquirer e.g. clear existing film csv if exists, option to put in file paths, api key into terminal
 
 #### Recent versions
+#### Version 1.4.4
+- [x] Look into fix for films with alternate titles (x AKA y)
+
 ##### Version 1.4.3
 - [x] Add resolution dupe check https://github.com/pizzaolive/ant_upload_checker/issues/16. Process will check if the specific resolution of your films are on ANT already or not.
 

--- a/ant_upload_checker/main.py
+++ b/ant_upload_checker/main.py
@@ -20,7 +20,7 @@ def main():
 
     write_film_list_to_csv(films_checked_on_ant)
 
-    logging.info("Script has ended")
+    logging.info("\nScript has ended")
 
 
 if __name__ == "__main__":

--- a/ant_upload_checker/output.py
+++ b/ant_upload_checker/output.py
@@ -6,7 +6,7 @@ import logging
 def write_film_list_to_csv(output_df):
     if not output_df.empty:
         output_file_path = Path(OUTPUT_FOLDER).joinpath("Film list.csv")
-        logging.info(f"Writing list of films to {output_file_path} ...")
+        logging.info("\nWriting list of films to %s...", output_file_path)
         output_df.to_csv(output_file_path, index=False, encoding="utf-8-sig")
     else:
-        logging.warning("The film list is empty, no file is being created.")
+        logging.warning("\nThe film list is empty, no file is being created.")

--- a/ant_upload_checker/setup.py
+++ b/ant_upload_checker/setup.py
@@ -2,6 +2,4 @@ import logging
 
 
 def setup_logging():
-    logging.basicConfig(
-        level=logging.INFO, format="%(asctime)s %(message)s", datefmt="%H:%M:%S"
-    )
+    logging.basicConfig(level=logging.INFO, format="%(message)s")

--- a/ant_upload_checker/tests/test_film_searcher.py
+++ b/ant_upload_checker/tests/test_film_searcher.py
@@ -233,3 +233,56 @@ def test_search_for_film_if_contains_potential_date_false(
 
     assert actual_return == "NOT FOUND"
     assert "Film title may contain a date or time" not in caplog.text
+
+
+films_with_alternate_titles = {
+    "Alphaville une etrange aventure de Lemmy Caution AKA Alphaville": (
+        "Alphaville une etrange aventure de Lemmy Caution",
+        "Alphaville",
+    ),
+    "Title 1 aka Title 2": ("Title 1", "Title 2"),
+}
+
+
+@pytest.mark.parametrize("test_film", films_with_alternate_titles)
+def test_search_for_film_if_contains_aka_true(
+    return_mock_search_for_film_on_ant_not_found, caplog, test_film
+):
+    caplog.set_level(logging.INFO)
+
+    fs = FilmSearcher("test", "test_api_key")
+    actual_return = fs.search_for_film_if_contains_aka(test_film)
+
+    assert actual_return == "NOT FOUND"
+    assert "Film title may contain an alternate title" in caplog.text
+    assert (
+        f"Searching for {films_with_alternate_titles[test_film][0]} as well"
+        in caplog.text
+    )
+    assert (
+        f"Searching for {films_with_alternate_titles[test_film][1]} as well"
+        in caplog.text
+    )
+
+
+films_with_no_alternate_title = [
+    "Aka Test film",
+    "Test film aka",
+    "Film with baka in it"
+]
+
+
+@pytest.mark.parametrize("test_film", films_with_no_alternate_title)
+def test_search_for_film_if_contains_aka_false(
+    return_mock_search_for_film_on_ant_not_found, caplog, test_film
+):
+    caplog.set_level(logging.INFO)
+
+    fs = FilmSearcher("test", "test_api_key")
+    actual_return = fs.search_for_film_if_contains_aka(test_film)
+
+    assert actual_return == "NOT FOUND"
+    assert "Film title may contain an alternate title" not in caplog.text
+    assert (
+        f"Searching for Test film as well" not in caplog.text
+    )

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+Version 1.4.4
+* Films with potential alternate titles (e.g. Film 1 AKA Film 2) are now split apart and re-searched if not initially found (closes Issue #4).
+* Tidier logging formatting.
+
 Version 1.4.3
 * Process now checks if a film's specific resolution is already uploaded to ANT as well. If the resolution is missing then it can likely be uploaded even if the film exists on ANT. If the resolution can't be extracted from the file name, then it will just check if it exists on ANT.
 * If a film_list.csv is found from previous versions, this won't be compatible with this new update, so if a file is found, this is backed up in case users want this to be kept.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ANT_upload_checker"
-version = "1.4.3"
+version = "1.4.4"
 authors = [
     { name = "pizzaolive"}
 ]


### PR DESCRIPTION
Version 1.4.4
* Films with potential alternate titles (e.g. Film 1 AKA Film 2) are now split apart and re-searched if not initially found (closes Issue #4).
* Tidier logging formatting.